### PR TITLE
hidden symbols as decls front-appended to parser-result

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ all: $(EXEC)
 compiler: $(COMPILER)
 
 ## compiles all test targets
+tests: $(TESTS)
+
 ## test targets
 test: tests/test.c
 	gcc -o $@ $^

--- a/README.txt
+++ b/README.txt
@@ -24,14 +24,14 @@ Changes since assignment 4:
 5. struct symbol now has an address field to have during code generation
    this saves the address value for a symbol while they are being generated.
 
-****************************
-1. Register field of expr has default unused value of -1.
-2. Which field of symbol has default unused value of -1.
-3. scratch allocation failure returns -1 if no halt.
-4. scratch name failure returns NULL if no halt.
-5. label create failure returns INT_MIN if no halt.
-6. symbol codegen failure returns NULL if no halt.
+6. symbol table now includes 'hidden' symbols: originally nameless array and string literals stored as symbols under a new name: the label
+  name generated from label_name() and label_create().This makes sure that pass-by-reference values are being stored and loaded correctly.
 
+7. <<struct>>_codegen functions now have an 'fprintf' variant, as <<struct>>_fcodegen():
+  These have an additonal parameter of the file pointer, which defaults to stdout.
+
+****************************
+HIDDEN SYMBOLS
 
 
 ******************************************************************************************************
@@ -59,32 +59,3 @@ use assembly emulator to help you.
 	- fcall
 		implement
 		test
-
-5. Arrays and strings are passed by reference, meaning their labels have to be generated even if a literal.
-   Therefore it is necessary to run symbol_codegen() throughout the symbol table prior to any <struct>_codegen() call.
-   Though this would require adding literals to the symbol table, they can be 'hidden'. Stored in the table but never printed, their
-   names are the label name generated from them via label_name(). This also requires #include for stmt.h and decl.h to have access to those
-   functions.
-
-
-
-CAVEATS:
-*************************************************************************************************
-
-- symbol table now includes 'hidden' symbols: originally nameless array and string literals stored as symbols under a new name: the label
-  name generated from label_name() and label_create().This makes sure that pass-by-reference values are being stored and loaded correctly.
-  These symbols are not shown as actual symbol table members, but can be with these functions:
-	- symbol_table_print()
-	- symbol_table_fprint()
-	- hash_table_print()
-	- hash_table_fprint()
-
-  though this will require renaming these functions and let them take an additional boolean parameter for show_hidden and making wrapper
-  functions:
-	- symbol_table_print() and symbol_table_print_hidden() will then become wrapper functions for a function that uses the original
-	  symbol_table_print() definition and an additional boolean parameter.
-	- ditto with hash_table_print() and their fprint variants
-
-
-- <<struct>>_codegen functions now have an 'fprintf' variant, as <<struct>>_fcodegen():
-  These have an additonal parameter of the file pointer, which defaults to stdout.

--- a/source/codegen.c
+++ b/source/codegen.c
@@ -12,6 +12,10 @@ extern FILE *REG_ERR_OUT, *ERR_OUT;
 extern struct stmt* test_parser_result;
 extern struct decl* parser_result;
 
+// other outputs
+extern struct decl* decl_hidden_list = NULL;
+extern struct decl* decl_hidden_list_tail = NULL;
+
 int main(int argc, const char** argv) {
   ERR_OUT = REG_ERR_OUT = stderr;
   printf("Hello world!\n");

--- a/source/decl.h
+++ b/source/decl.h
@@ -22,6 +22,11 @@ struct decl {
 	struct decl* next;
 };
 
+
+// for hidden symbols
+struct decl* decl_hidden_list;
+struct decl* decl_hidden_list_tail;
+
 struct decl* decl_create(char* name, struct type* type, struct expr* value, struct stmt* code, struct decl* next);
 
 void decl_fprint(FILE* fp, struct decl* d, int indent);
@@ -39,5 +44,5 @@ int decl_resolve(struct symbol_table* st, struct decl* d);
 
 int decl_typecheck(struct symbol_table*, struct decl* d);
 
-#endif
+#endif /* DECL_H */
 

--- a/source/expr.c
+++ b/source/expr.c
@@ -279,6 +279,13 @@ int expr_resolve(struct symbol_table* st, struct expr* e) {
     label_name(label_create()); // stored in global label_str
     e->symbol = symbol_create(SYMBOL_HIDDEN, type_create(TYPE_STRING, NULL, NULL, NULL), strdup(label_str));
     symbol_table_scope_bind(st, strdup(label_str), e->symbol);
+
+    // add it to hidden delcarations
+    struct decl* d = decl_create(strdup(label_str), type_create(TYPE_STRING, NULL, NULL, NULL), e, NULL, NULL);
+    if (!decl_hidden_list) { decl_hidden_list = d; }
+    else { decl_hidden_list_tail->next = d; }
+    decl_hidden_list_tail = d;
+
     break;
   default:
     error_status = expr_resolve(st, e->left);

--- a/source/expr.h
+++ b/source/expr.h
@@ -103,4 +103,4 @@ An error code is emitted and send to the error message handler.
 */
 int expr_codegen(struct expr* e);
 
-#endif
+#endif /* EXPR_H */

--- a/source/grammar.bison
+++ b/source/grammar.bison
@@ -23,7 +23,6 @@
   // parser results
   struct stmt* test_parser_result = NULL; // for testing
   struct decl* parser_result = NULL;
-  
 %}
 %expect 3
 %define parse.error verbose

--- a/source/param_list.h
+++ b/source/param_list.h
@@ -27,4 +27,4 @@ bool param_list_equals(struct param_list* a, struct param_list* b);
 
 int param_list_resolve(struct symbol_table* st, struct param_list* p);
 
-#endif
+#endif /* PARAM_LIST_H */

--- a/source/register.h
+++ b/source/register.h
@@ -1,4 +1,6 @@
-#pragma once
+#ifndef REGISTER_H
+#define REGISTER_H
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -85,3 +87,5 @@ int label_create();
 Creates a label string value
 */
 const char* label_name(int label);
+
+#endif /* REGISTER_H */

--- a/source/stmt.h
+++ b/source/stmt.h
@@ -48,4 +48,4 @@ int stmt_resolve(struct symbol_table* st, struct stmt* s);
 
 int stmt_typecheck(struct symbol_table* st, struct stmt* s, struct type** ret_type);
 
-#endif
+#endif /* STMT_H */

--- a/source/symbol.h
+++ b/source/symbol.h
@@ -30,4 +30,4 @@ struct symbol* symbol_copy(struct symbol* s);
 const char* symbol_codegen(struct symbol* s);
 
 
-#endif
+#endif /* SYMBOL_H */

--- a/source/symbol_table.h
+++ b/source/symbol_table.h
@@ -1,4 +1,6 @@
-#pragma once
+#ifndef SYMBOL_TABLE_H
+#define SYMBOL_TABLE_H
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -199,3 +201,5 @@ foo --> (kind: global, name: foo, type: function void (x: integer, y: char, z: b
 */
 void symbol_table_fprint(FILE* fp, struct symbol_table* st);
 void symbol_table_print(struct symbol_table* st);
+
+#endif /* SYMBOL_TABLE_H */

--- a/source/type.h
+++ b/source/type.h
@@ -45,4 +45,4 @@ Adds symbols with parameter scopes
 */
 int type_resolve(struct symbol_table* st, struct type* t);
 
-#endif
+#endif /* TYPE_H */

--- a/source/typecheck.c
+++ b/source/typecheck.c
@@ -13,6 +13,10 @@ extern FILE* ERR_OUT;
 extern struct stmt* test_parser_result;
 extern struct decl* parser_result;
 
+// other outputs
+extern struct decl* decl_hidden_list = NULL;
+extern struct decl* decl_hidden_list_tail = NULL;
+
 // command line stuff
 bool refresh = false, show_hidden = false;
 struct symbol_table* st = NULL;
@@ -37,11 +41,14 @@ int main(int argc, const char* argv[]) {
     } else { print_error_message(); }
   }
   if (parser_result) {
-    decl_print(parser_result, 0); printf("\n");
     decl_resolve(st, parser_result);
     decl_typecheck(st, parser_result);
+
+    decl_print(decl_hidden_list, 0); printf("\n");
+    decl_print(parser_result, 0); printf("\n");
     symbol_table_print(st);
-    decl_destroy(&parser_result);
+    decl_destroy(&decl_hidden_list);
+    decl_destroy(&decl_hidden_list_tail);
     printf("Total errors: %d\n", global_error_count);
   }
   symbol_table_destroy(&st);


### PR DESCRIPTION
(not really front-appended but `decl_codegen()` won't care if it's called twice on different declaration lists).

Hidden symbols are now 'appended' (see above) to `struct decl* parser_result` so that when it comes to `decl_codegen()`, all necessary symbols, including hidden symbols, will be in the list(s), with no need to look through the symbol table several times to check for symbols that may not even be in the table (if no string literals are ever used for instance).